### PR TITLE
Add version number and some small changes

### DIFF
--- a/metadata-schema.json
+++ b/metadata-schema.json
@@ -21,7 +21,7 @@
                     "type": "object",
                     "properties": {
                         "lshw": {
-                            "type": "object",
+                            "type": "array",
                             "description": "The output of lshw as JSON"
                         }
                     }
@@ -34,7 +34,7 @@
                             "description": "The output from tools such as nvidia-smi as JSON"
                         },
                         "requirements": {
-                            "type": "object",
+                            "type": "array",
                             "description": "the python libraries used as a list of strings"
                         }
                     }

--- a/metadata-schema.json
+++ b/metadata-schema.json
@@ -1,9 +1,15 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/odgaard/TuningSchema/blob/main/MetadataSchema.json",
+    "$id": "https://github.com/odgaard/TuningSchema/blob/T4/metadata-schema.json",
     "title": "Open Autotuning Metadata Schema",
     "type": "object",
     "properties": {
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "1.0.0"
+        },
         "metadata": {
             "type": "object",
             "properties": {
@@ -23,16 +29,16 @@
                 "environment": {
                     "type": "object",
                     "properties": {
-                        "nvidia_query": { 
+                        "device_query": {
                             "type": "object",
-                            "description": "The output from nvidia-smi as JSON" 
+                            "description": "The output from tools such as nvidia-smi as JSON"
                         },
                         "requirements": {
                             "type": "object",
                             "description": "the python libraries used as a list of strings"
                         }
                     }
-                }            
+                }
             }
         }
    }

--- a/results-schema.json
+++ b/results-schema.json
@@ -1,9 +1,15 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/odgaard/TuningSchema/blob/main/ResultsSchema.json",
-    "title": "Open Autotuning Results Schema",
+    "$id": "https://github.com/odgaard/TuningSchema/blob/T4/results-schema.json",
+    "description": "Open Autotuning Results Schema",
     "type": "object",
     "properties": {
+       "schema_version": {
+         "description": "The version number of the schema in major.minor.patch format.",
+         "type": "string",
+         "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+         "example": "1.0.0"
+       },
        "results": {
             "type": "array",
             "items": {

--- a/results-schema.json
+++ b/results-schema.json
@@ -45,7 +45,7 @@
                         }
                     },
                     "invalidity": {
-                        "enum": ["timeout", "compile", "runtime", "correctness", "constraints"]
+                        "enum": ["timeout", "compile", "runtime", "correctness", "constraints", "correct"]
                     },
                     "correctness": {
                         "type": "number"


### PR DESCRIPTION
I just implemented the first version of a set of functions to create a result and metadata file according to the schema. For this I had to make a few small changes to the schema, such as adding the 'correct' label to the options in the 'invalidity' field. 

The most profound change is perhaps the suggestion to use semantic versioning to version the schema. I've also made some smaller changes:

To be a bit more vendor independent, I suggest we rename 'nvidia-query' to 'device-query'. I even wrote a function to parse rocm-smi output (which kindly supports outputing JSON) and store it in the metadata.

Also in the metadata schema, I had to change two fields to 'array' instead of object because lshw returns a JSON object that is a list and the jsonschema validation gave an error if the field is a list and the schema expects an 'object'. Apparently a list is not an object, who knew ;-)





