### PR TITLE
Add a script for printing hardware info and readme with info on paper and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+This repository contains aids and tools to make the data sharing in autotuning easier.
+
+You can find details about the guidelines and the recommendations in paper FAIR Sharing of Data in Autotuning Research, https://doi.org/10.1145/3629527.3651429
+
+You can find an example of data shared according to those guidelines in repository Autotuning data for KTT Coulomb3d CUDA example, https://doi.org/10.5281/zenodo.11026350

--- a/get_hardware_info.py
+++ b/get_hardware_info.py
@@ -1,0 +1,6 @@
+from metadata import Metadata
+import json
+
+metadata = Metadata.get_metadata_without_zenodo()
+with open('hardware_info.json', "w") as fp:
+    json.dump(metadata, fp, indent=4)

--- a/metadata.py
+++ b/metadata.py
@@ -3,8 +3,6 @@ import json
 import jc
 import xmltodict
 
-from batbench.result.zenodo import Zenodo
-
 class Metadata:
     """
     A class that provides methods to retrieve metadata about the environment and hardware.
@@ -12,7 +10,15 @@ class Metadata:
     @staticmethod
     def get_metadata():
         metadata = {}
+        from batbench.result.zenodo import Zenodo
         metadata["zenodo"] = Zenodo.get_zenodo_metadata()
+        metadata["environment"] = Metadata.get_environment_metadata()
+        metadata["hardware"] = Metadata.get_hardware_metadata()
+        return metadata
+
+    @staticmethod
+    def get_metadata_without_zenodo():
+        metadata = {}
         metadata["environment"] = Metadata.get_environment_metadata()
         metadata["hardware"] = Metadata.get_hardware_metadata()
         return metadata
@@ -46,8 +52,11 @@ class Metadata:
 
     @staticmethod
     def save_requirements():
-        with open("requirements.txt", 'r', encoding='utf-8') as file:
-            requirements_list = [line.strip() for line in file.readlines()]
+        try:
+            with open("requirements.txt", 'r', encoding='utf-8') as file:
+                requirements_list = [line.strip() for line in file.readlines()]
+        except FileNotFoundError:
+            return []
         return requirements_list
 
     @staticmethod


### PR DESCRIPTION
I have added a script get_hardware_info.py that is able to write hardware information into json file without uploading to Zenodo. I modified metadata.py, most notably I have made import of batbench.result.zenodo conditional, i.e. it imports only if necessary. That way the user that does not want to upload to Zenodo does not need to install that package.

Readme file contains links to paper and the example I have prepared, so everything related is ready and available.