### PR TITLE
Update TuningSchema.json

### DIFF
--- a/TuningSchema.json
+++ b/TuningSchema.json
@@ -380,6 +380,16 @@
                         },
                         "RandomSeed": {
                             "type": "integer"
+                        },
+                        "ValidationMethod": {
+                            "enum": [
+                                "AbsoluteDifference",
+                                "SideBySideComparison",
+                                "SideBySideRelativeComparison"
+                            ]
+                        },
+                        "ValidationThreshold": {
+                            "type": "number"
                         }
                     }
                 }

--- a/TuningSchema.json
+++ b/TuningSchema.json
@@ -168,10 +168,13 @@
                 "Device": {
                     "type": "object",
                     "required": [
-                        "Id"
+                        "DeviceId"
                     ],
                     "properties": {
-                        "Id": {
+                        "PlatformId": {
+                            "type: "integer"
+                        },
+                        "DeviceId": {
                             "type": "integer"
                         },
                         "Name": {

--- a/TuningSchema.json
+++ b/TuningSchema.json
@@ -165,6 +165,20 @@
                 "LocalSize"
             ],
             "properties": {
+                "Device": {
+                    "type": "object",
+                    "required": [
+                        "Id"
+                    ],
+                    "properties": {
+                        "Id": {
+                            "type": "integer"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "Language": {
                     "enum": [
                         "OpenCL",
@@ -178,17 +192,14 @@
                         "type": "string"
                     }
                 },
+                "Profiling": {
+                    "type": "boolean"
+                },                    
                 "KernelName": {
                     "type": "string"
                 },
                 "KernelFile": {
                     "type": "string"
-                },
-                "KernelTypeNames": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 },
                 "GlobalSizeType": {
                     "enum": [
@@ -312,6 +323,9 @@
                             "DataSource": {
                                 "type": "string"
                             },
+                            "RandomSeed": {
+                                "type": "integer"
+                            },
                             "AccessType": {
                                 "enum": [
                                     "ReadOnly",
@@ -363,6 +377,9 @@
                         },
                         "DataSource": {
                             "type": "string"
+                        },
+                        "RandomSeed": {
+                            "type": "integer"
                         }
                     }
                 }

--- a/TuningSchema.json
+++ b/TuningSchema.json
@@ -167,12 +167,9 @@
             "properties": {
                 "Device": {
                     "type": "object",
-                    "required": [
-                        "DeviceId"
-                    ],
                     "properties": {
                         "PlatformId": {
-                            "type: "integer"
+                            "type": "integer"
                         },
                         "DeviceId": {
                             "type": "integer"


### PR DESCRIPTION
Based on the discussion we had, I propose to add properties
- Device into KernelSpecification. Device consists of Id (this is how the device for the execution is set, default 0) and Name (to increase readability, the user can note here that device with id 0 is e.g. GPU Nvidia GTX 1070). Not required, if specified, Id needs to be set.
- Profiling into KernelSpecification. Boolean, if true, profiling is turned on. Default false. Not required.
- random seed for every kernel Argument and ReferenceArgument. Applicable when the data are randomly generated, i.e. FillType Random, in some cases also Generator and Script. Not required.

Note: The random seed for the search method can be specified as one of Attributes in Search.

I also propose to remove KernelTypeNames as these are not applied in any autotuner and their initial purpose is not clear.