### PR TITLE
Fix schema error in ReferenceArguments

### DIFF
--- a/TuningSchema.json
+++ b/TuningSchema.json
@@ -346,50 +346,53 @@
                 },
                 "ReferenceArguments": {
                     "type": "array",
-                    "required": [
-                        "Name",
-                        "TargetName",
-                        "FillType"
-                    ],
-                    "properties": {
-                        "Name": {
-                            "type": "string"
-                        },
-                        "TargetName": {
-                            "type": "string"
-                        },
-                        "FillType": {
-                            "enum": [
-                                "Constant",
-                                "Random",
-                                "Generator",
-                                "Script",
-                                "BinaryRaw",
-                                "BinaryHDF"
-                            ]
-                        },
-                        "FillValue": {
-                            "type": "number",
-                            "examples": [
-                                40,
-                                1.0
-                            ]
-                        },
-                        "DataSource": {
-                            "type": "string"
-                        },
-                        "RandomSeed": {
-                            "type": "integer"
-                        },
-                        "ValidationMethod": {
-                            "enum": [
-                                "AbsoluteDifference",
-                                "SideBySideComparison",
-                                "SideBySideRelativeComparison"
-                            ]
-                        },
-                        "ValidationThreshold": {
-                            "type": "number"
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "Name",
+                            "TargetName",
+                            "FillType"
+                        ],
+                        "properties": {
+                            "Name": {
+                                "type": "string"
+                            },
+                            "TargetName": {
+                                "type": "string"
+                            },
+                            "FillType": {
+                                "enum": [
+                                    "Constant",
+                                    "Random",
+                                    "Generator",
+                                    "Script",
+                                    "BinaryRaw",
+                                    "BinaryHDF"
+                                ]
+                            },
+                            "FillValue": {
+                                "type": "number",
+                                "examples": [
+                                    40,
+                                    1.0
+                                ]
+                            },
+                            "DataSource": {
+                                "type": "string"
+                            },
+                            "RandomSeed": {
+                                "type": "integer"
+                            },
+                            "ValidationMethod": {
+                                "enum": [
+                                    "AbsoluteDifference",
+                                    "SideBySideComparison",
+                                    "SideBySideRelativeComparison"
+                                ]
+                            },
+                            "ValidationThreshold": {
+                                "type": "number"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Missing "items" in ReferenceArguments caused validating even invalid json files.